### PR TITLE
feature/refactor-scheduler-api

### DIFF
--- a/examples/scheduler/main.cpp
+++ b/examples/scheduler/main.cpp
@@ -25,7 +25,7 @@ int main() {
   scheduler.spawn([]() -> ecoro::task<void> {
     auto *scheduler = co_await ecoro::this_coro::scheduler();
     while (true) {
-      co_await scheduler->sleep_for(1s);
+      co_await scheduler->schedule_after(1s);
       std::cout << "1s\n";
     }
   });

--- a/examples/scheduler/scheduler.cpp
+++ b/examples/scheduler/scheduler.cpp
@@ -35,7 +35,7 @@ int scheduler::exec() {
   return 1;
 }
 
-ecoro::task<void> scheduler::sleep_for(
+ecoro::task<void> scheduler::schedule_after(
     const std::chrono::seconds seconds) noexcept {
   co_return co_await timer_awaiter{
       *this, std::chrono::time_point_cast<std::chrono::seconds>(

--- a/examples/scheduler/scheduler.hpp
+++ b/examples/scheduler/scheduler.hpp
@@ -22,7 +22,7 @@ class scheduler : public ecoro::scheduler {
     void await_resume() const noexcept;
 
     scheduler &scheduler_;
-    const std::chrono::time_point<std::chrono::system_clock> when;
+    std::chrono::steady_clock::time_point when;
     std::coroutine_handle<> handle;
   };
 
@@ -37,7 +37,7 @@ class scheduler : public ecoro::scheduler {
   int exec();
 
   [[nodiscard]] ecoro::task<void> schedule_after(
-      const std::chrono::seconds seconds) noexcept override;
+      const std::chrono::nanoseconds delay) noexcept override;
 
  protected:
   void add_timer_awaiter(timer_awaiter *timer);

--- a/examples/scheduler/scheduler.hpp
+++ b/examples/scheduler/scheduler.hpp
@@ -36,7 +36,7 @@ class scheduler : public ecoro::scheduler {
   void shutdown();
   int exec();
 
-  [[nodiscard]] ecoro::task<void> sleep_for(
+  [[nodiscard]] ecoro::task<void> schedule_after(
       const std::chrono::seconds seconds) noexcept override;
 
  protected:

--- a/include/ecoro/scheduler.hpp
+++ b/include/ecoro/scheduler.hpp
@@ -14,7 +14,7 @@ namespace ecoro {
 
 class scheduler {
  public:
-  [[nodiscard]] virtual task<void> sleep_for(
+  [[nodiscard]] virtual task<void> schedule_after(
       const std::chrono::seconds seconds) noexcept = 0;
 };
 

--- a/include/ecoro/scheduler.hpp
+++ b/include/ecoro/scheduler.hpp
@@ -15,7 +15,7 @@ namespace ecoro {
 class scheduler {
  public:
   [[nodiscard]] virtual task<void> schedule_after(
-      const std::chrono::seconds seconds) noexcept = 0;
+      const std::chrono::nanoseconds delay) noexcept = 0;
 };
 
 }  // namespace ecoro

--- a/include/ecoro/this_coro.hpp
+++ b/include/ecoro/this_coro.hpp
@@ -40,7 +40,7 @@ struct scheduler_awaiter {
 template<typename Duration>
 [[nodiscard]] task<void> sleep_for(Duration &&duration) {
   auto *e = co_await scheduler();
-  co_await e->sleep_for(std::forward<Duration>(duration));
+  co_await e->schedule_after(std::forward<Duration>(duration));
 }
 
 }  // namespace ecoro::this_coro


### PR DESCRIPTION
- scheduler: Rename sleep_for -> schedule_after
- scheduler: schedule_after accept nanoseconds instead of milliseconds
